### PR TITLE
Allow direct creation of nested segments and generalise transaction/segment relationship

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
     TransactionStartError,
     /// There was an error changing the name of the transaction
     TransactionNameError,
+    /// Check the New Relic SDK logs for more details.
+    /// The segment could not be started.
+    SegmentStartError,
     /// A string parameter contained a null byte and could not be converted
     /// to a CString.
     NulError(NulError),
@@ -82,7 +85,10 @@ impl fmt::Display for Error {
             ),
             Error::TransactionStartError => {
                 write!(f, "Error starting transaction; {}", CHECK_NEW_RELIC_LOGS)
-            }
+            },
+            Error::SegmentStartError => {
+                write!(f, "Error starting segment; {}", CHECK_NEW_RELIC_LOGS)
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ pub use app::{App, AppBuilder, AppConfig, LogOutput, NewRelicConfig, RecordSQL, 
 pub use error::{Error, Result};
 pub use event::CustomEvent;
 pub use segment::{
-    Datastore, DatastoreParams, DatastoreParamsBuilder, ExternalParams, ExternalParamsBuilder,
-    Segment,
+    BorrowingSegment, Datastore, DatastoreParams, DatastoreParamsBuilder, ExternalParams,
+    ExternalParamsBuilder, Segment,
 };
 pub use transaction::{Attribute, Transaction};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use app::{App, AppBuilder, AppConfig, LogOutput, NewRelicConfig, RecordSQL, 
 pub use error::{Error, Result};
 pub use event::CustomEvent;
 pub use segment::{
-    BorrowingSegment, Datastore, DatastoreParams, DatastoreParamsBuilder, ExternalParams,
+    ReferencingSegment, Datastore, DatastoreParams, DatastoreParamsBuilder, ExternalParams,
     ExternalParamsBuilder, Segment,
 };
 pub use transaction::{Attribute, Transaction};

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -348,7 +348,12 @@ impl<T: Borrow<Transaction> + Clone> BorrowingSegment<T> {
     ///     expensive_val_1 * expensive_val_2
     /// };
     /// ```
-    pub fn custom_nested<F, V>(&self, name: &str, category: &str, func: F) -> Result<V>
+    pub fn custom_nested<F, V>(
+        &self,
+        name: impl Borrow<str>,
+        category: impl Borrow<str>,
+        func: F,
+    ) -> Result<V>
         where
             F: FnOnce(BorrowingSegment<T>) -> V,
     {
@@ -386,7 +391,11 @@ impl<T: Borrow<Transaction> + Clone> BorrowingSegment<T> {
     ///     expensive_val * 2
     /// };
     /// ```
-    pub fn datastore_nested<F, V>(&self, params: &DatastoreParams, func: F) -> Result<V>
+    pub fn datastore_nested<F, V>(
+        &self,
+        params: impl Borrow<DatastoreParams>,
+        func: F,
+    ) -> Result<V>
         where
             F: FnOnce(BorrowingSegment<T>) -> V,
     {
@@ -424,7 +433,11 @@ impl<T: Borrow<Transaction> + Clone> BorrowingSegment<T> {
     ///     expensive_val * 2
     /// };
     /// ```
-    pub fn external_nested<F, V>(&self, params: &ExternalParams, func: F) -> Result<V>
+    pub fn external_nested<F, V>(
+        &self,
+        params: impl Borrow<ExternalParams>,
+        func: F,
+    ) -> Result<V>
         where
             F: FnOnce(BorrowingSegment<T>) -> V,
     {
@@ -458,8 +471,13 @@ impl<T: Borrow<Transaction> + Clone> BorrowingSegment<T> {
     ///     thread::sleep(Duration::from_secs(1));
     /// };
     /// ```
-    pub fn create_custom_nested(&self, name: &str, category: &str) -> Result<Self> {
-        let sp = self.segment_pointer.custom_nested(self.transaction.borrow(), name, category)?;
+    pub fn create_custom_nested(
+        &self,
+        name: impl Borrow<str>,
+        category: impl Borrow<str>,
+    ) -> Result<Self> {
+        let sp = self.segment_pointer.custom_nested(
+            self.transaction.borrow(), name.borrow(), category.borrow())?;
         let transaction = self.transaction.clone();
         Ok(Self { segment_pointer: sp, transaction })
     }
@@ -493,8 +511,12 @@ impl<T: Borrow<Transaction> + Clone> BorrowingSegment<T> {
     ///     thread::sleep(Duration::from_secs(1));
     /// };
     /// ```
-    pub fn create_datastore_nested(&self, params: &DatastoreParams) -> Result<Self> {
-        let sp = self.segment_pointer.datastore_nested(self.transaction.borrow(), params)?;
+    pub fn create_datastore_nested(
+        &self,
+        params: impl Borrow<DatastoreParams>,
+    ) -> Result<Self> {
+        let sp = self.segment_pointer.datastore_nested(
+            self.transaction.borrow(), params.borrow())?;
         let transaction = self.transaction.clone();
         Ok(Self { segment_pointer: sp, transaction })
     }
@@ -528,8 +550,12 @@ impl<T: Borrow<Transaction> + Clone> BorrowingSegment<T> {
     ///     thread::sleep(Duration::from_secs(1));
     /// };
     /// ```
-    pub fn create_external_nested(&self, params: &ExternalParams) -> Result<Self> {
-        let sp = self.segment_pointer.external_nested(self.transaction.borrow(), params)?;
+    pub fn create_external_nested(
+        &self,
+        params: impl Borrow<ExternalParams>,
+    ) -> Result<Self> {
+        let sp = self.segment_pointer.external_nested(
+            self.transaction.borrow(), params.borrow())?;
         let transaction = self.transaction.clone();
         Ok(Self { segment_pointer: sp, transaction })
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -625,10 +625,6 @@ impl<T: Borrow<Transaction> + Clone> Drop for BorrowingSegment<T> {
     }
 }
 
-unsafe impl<T: Borrow<Transaction> + Clone> Send for BorrowingSegment<T> {}
-
-unsafe impl<T: Borrow<Transaction> + Clone> Sync for BorrowingSegment<T> {}
-
 /// A segment within a transaction.
 ///
 /// Use segments to instrument transactions with greater granularity.
@@ -1262,3 +1258,8 @@ impl Drop for DatastoreParams {
         }
     }
 }
+
+unsafe impl Send for DatastoreParams {}
+
+unsafe impl Sync for DatastoreParams {}
+

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -69,7 +69,7 @@ impl<'a> From<&'a String> for Attribute<'a> {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 enum State {
     Running,
     Ended,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -40,6 +40,7 @@ impl<'a> From<i32> for Attribute<'a> {
         Attribute::Int(original)
     }
 }
+
 impl<'a> From<i64> for Attribute<'a> {
     #[allow(unused_variables)]
     #[inline]
@@ -47,6 +48,7 @@ impl<'a> From<i64> for Attribute<'a> {
         Attribute::Long(original)
     }
 }
+
 impl<'a> From<f64> for Attribute<'a> {
     #[allow(unused_variables)]
     #[inline]
@@ -54,6 +56,7 @@ impl<'a> From<f64> for Attribute<'a> {
         Attribute::Float(original)
     }
 }
+
 impl<'a> From<&'a str> for Attribute<'a> {
     #[allow(unused_variables)]
     #[inline]
@@ -61,6 +64,7 @@ impl<'a> From<&'a str> for Attribute<'a> {
         Attribute::String(original)
     }
 }
+
 impl<'a> From<&'a String> for Attribute<'a> {
     #[allow(unused_variables)]
     #[inline]
@@ -124,8 +128,8 @@ impl Transaction {
     ///
     /// Returns an error if the New Relic SDK returns an error.
     pub fn add_attribute<'a, T>(&self, name: &str, attribute: T) -> Result<()>
-    where
-        T: Into<Attribute<'a>>,
+        where
+            T: Into<Attribute<'a>>,
     {
         let name = CString::new(name)?;
         let ok = match attribute.into() {
@@ -175,8 +179,8 @@ impl Transaction {
     /// });
     /// ```
     pub fn custom_segment<F, V>(&self, name: &str, category: &str, func: F) -> V
-    where
-        F: FnOnce(Segment) -> V,
+        where
+            F: FnOnce(Segment) -> V,
     {
         let segment = Segment::custom(self, name, category);
         func(segment)
@@ -208,8 +212,8 @@ impl Transaction {
     /// });
     /// ```
     pub fn datastore_segment<F, V>(&self, params: &DatastoreParams, func: F) -> V
-    where
-        F: FnOnce(Segment) -> V,
+        where
+            F: FnOnce(Segment) -> V,
     {
         let segment = Segment::datastore(self, params);
         func(segment)
@@ -241,8 +245,8 @@ impl Transaction {
     /// });
     /// ```
     pub fn external_segment<F, V>(&self, params: &ExternalParams, func: F) -> V
-    where
-        F: FnOnce(Segment) -> V,
+        where
+            F: FnOnce(Segment) -> V,
     {
         let segment = Segment::external(self, params);
         func(segment)
@@ -436,5 +440,12 @@ impl Drop for Transaction {
     }
 }
 
+impl AsRef<Self> for Transaction {
+    fn as_ref(&self) -> &Self {
+        &self
+    }
+}
+
 unsafe impl Send for Transaction {}
+
 unsafe impl Sync for Transaction {}


### PR DESCRIPTION
**Ready for Review**

Allow creation of nested segments to parallel create segment functions in transaction.

Allow creation of segments with a reference to its transaction specified by any implementor of the borrow trait.
This allows the introduction of constructs such as reference counters, which take ownership of the transaction,
and allow deferring lifetime checks until runtime.
This has the advantage of allowing segments to be sent in closures which require static lifetimes, such as thread functions inside the widely used tokio framework.

The original transaction implementation has been left intact functionally, as have all of the functions on the transaction, making this backwards compatible.
Underneath the hood, the existing segment now wraps the borrowing segment, which will happily except a simple reference to a transaction.

Comment:
I noticed that when I run cargo test the doc examples fail because of course there is no new relic environment. I wasn't sure if somebody was testing these using those doc examples with an environment that did work. I was tempted to add a `no_run` to the end of the rust tag, but I decided not to. If, however, this would be good, I could add that back in.