### PR TITLE
HOTFIX: Fixes for failing examples

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -235,7 +235,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Test transaction")
     ///     .expect("Could not start transaction");
     /// {
-    ///     let _ = ReferencingSegment::custom("Test segment", "Test category", &transaction);
+    ///     let _ = ReferencingSegment::custom(&transaction, "Test segment", "Test category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1))
     /// }
     /// ```
@@ -273,7 +274,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .build()
     ///     .expect("Invalid datastore segment parameters");
     /// {
-    ///     let _ = ReferencingSegment::datastore(&segment_params, &transaction);
+    ///     let _ = ReferencingSegment::datastore(&transaction, &segment_params)
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1))
     /// }
     /// ```
@@ -307,7 +309,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .build()
     ///     .expect("Invalid external segment parameters");
     /// {
-    ///     let _ = ReferencingSegment::external(&segment_params, &transaction);
+    ///     let _ = ReferencingSegment::external(&transaction, &segment_params)
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1))
     /// }
     /// ```
@@ -339,16 +342,17 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Transaction name")
     ///     .expect("Could not start transaction");
     /// let value = {
-    ///     let s = ReferencingSegment::custom("Segment name", "Segment category", &transaction);
+    ///     let s = ReferencingSegment::custom(&transaction, "Segment name", "Segment category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1));
     ///     let expensive_val_1 = s.custom_nested("First nested segment", "Nested category", |_| {
     ///         thread::sleep(Duration::from_secs(1));
     ///         3
-    ///     });
+    ///     }).expect("Could not start nested segment");
     ///     let expensive_val_2 = s.custom_nested("Second nested segment", "Nested category", |_| {
     ///         thread::sleep(Duration::from_secs(1));
     ///         2
-    ///     });
+    ///     }).expect("Could not start nested segment");
     ///     expensive_val_1 * expensive_val_2
     /// };
     /// ```
@@ -358,8 +362,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
         category: impl AsRef<str>,
         func: F,
     ) -> Result<V>
-    where
-        F: FnOnce(ReferencingSegment<T>) -> V,
+        where
+            F: FnOnce(ReferencingSegment<T>) -> V,
     {
         Ok(func(self.create_custom_nested(name, category)?))
     }
@@ -381,7 +385,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Transaction name")
     ///     .expect("Could not start transaction");
     /// let value = {
-    ///     let s = ReferencingSegment::custom("Segment name", "Segment category", &transaction);
+    ///     let s = ReferencingSegment::custom(&transaction, "Segment name", "Segment category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1));
     ///     let datastore_segment_params = DatastoreParamsBuilder::new(Datastore::Postgres)
     ///         .collection("people")
@@ -391,13 +396,13 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     let expensive_val = s.datastore_nested(&datastore_segment_params, |_| {
     ///         thread::sleep(Duration::from_secs(1));
     ///         3
-    ///     });
+    ///     }).expect("Could not start nested segment");
     ///     expensive_val * 2
     /// };
     /// ```
     pub fn datastore_nested<F, V>(&self, params: impl AsRef<DatastoreParams>, func: F) -> Result<V>
-    where
-        F: FnOnce(ReferencingSegment<T>) -> V,
+        where
+            F: FnOnce(ReferencingSegment<T>) -> V,
     {
         Ok(func(self.create_datastore_nested(params)?))
     }
@@ -419,7 +424,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Transaction name")
     ///     .expect("Could not start transaction");
     /// let value = {
-    ///     let s = ReferencingSegment.custom("Segment name", "Segment category", &transaction);
+    ///     let s = ReferencingSegment::custom(&transaction, "Segment name", "Segment category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1));
     ///     let external_segment_params = ExternalParamsBuilder::new("https://www.rust-lang.org/")
     ///         .procedure("GET")
@@ -429,13 +435,13 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     let expensive_val = s.external_nested(&external_segment_params, |_| {
     ///         thread::sleep(Duration::from_secs(1));
     ///         3
-    ///     });
+    ///     }).expect("Could not start nested segment");
     ///     expensive_val * 2
     /// };
     /// ```
     pub fn external_nested<F, V>(&self, params: impl AsRef<ExternalParams>, func: F) -> Result<V>
-    where
-        F: FnOnce(ReferencingSegment<T>) -> V,
+        where
+            F: FnOnce(ReferencingSegment<T>) -> V,
     {
         Ok(func(self.create_external_nested(params)?))
     }
@@ -460,7 +466,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Transaction name")
     ///     .expect("Could not start transaction");
     /// let value = {
-    ///     let s = ReferencingSegment::custom("Segment name", "Segment category", &transaction);
+    ///     let s = ReferencingSegment::custom(&transaction, "Segment name", "Segment category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1));
     ///     let _ = s.create_custom_nested("Second nested segment", "Nested category")
     ///         .expect("Could not start nested segment");
@@ -501,7 +508,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Transaction name")
     ///     .expect("Could not start transaction");
     /// let value = {
-    ///     let s = ReferencingSegment::custom("Segment name", "Segment category", &transaction);
+    ///     let s = ReferencingSegment::custom(&transaction, "Segment name", "Segment category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1));
     ///     let datastore_segment_params = DatastoreParamsBuilder::new(Datastore::Postgres)
     ///         .collection("people")
@@ -541,7 +549,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .web_transaction("Transaction name")
     ///     .expect("Could not start transaction");
     /// let value = {
-    ///     let s = ReferencingSegment::custom("Segment name", "Segment category", &transaction);
+    ///     let s = ReferencingSegment::custom(&transaction, "Segment name", "Segment category")
+    ///         .expect("Could not start segment");
     ///     thread::sleep(Duration::from_secs(1));
     ///     let external_segment_params = ExternalParamsBuilder::new("https://www.rust-lang.org/")
     ///         .procedure("GET")
@@ -599,7 +608,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     ///     .build()
     ///     .expect("Invalid external segment parameters");
     /// {
-    ///     let segment = ReferencingSegment::external(&segment_params, &transaction);
+    ///     let segment = ReferencingSegment::external(&transaction, &segment_params)
+    ///         .expect("Could not start segment");
     ///     let _header = segment.distributed_trace();
     ///     thread::sleep(Duration::from_secs(1))
     /// }
@@ -700,8 +710,8 @@ impl<'a> Segment<'a> {
     /// });
     /// ```
     pub fn custom_nested<F, V>(&self, name: &str, category: &str, func: F) -> V
-    where
-        F: FnOnce(Segment) -> V,
+        where
+            F: FnOnce(Segment) -> V,
     {
         func(self.create_custom_nested(name, category))
     }
@@ -737,8 +747,8 @@ impl<'a> Segment<'a> {
     /// });
     /// ```
     pub fn datastore_nested<F, V>(&self, params: &DatastoreParams, func: F) -> V
-    where
-        F: FnOnce(Segment) -> V,
+        where
+            F: FnOnce(Segment) -> V,
     {
         func(self.create_datastore_nested(params))
     }
@@ -774,8 +784,8 @@ impl<'a> Segment<'a> {
     /// });
     /// ```
     pub fn external_nested<F, V>(&self, params: &ExternalParams, func: F) -> V
-    where
-        F: FnOnce(Segment) -> V,
+        where
+            F: FnOnce(Segment) -> V,
     {
         func(self.create_external_nested(params))
     }
@@ -801,9 +811,16 @@ impl<'a> Segment<'a> {
     ///     .expect("Could not start transaction");
     /// let value = transaction.custom_segment("Segment name", "Segment category", |s| {
     ///     thread::sleep(Duration::from_secs(1));
-    ///     let _ = s.create_custom_nested("Second nested segment", "Nested category")
-    ///         .expect("Could not start nested segment");
-    ///     thread::sleep(Duration::from_secs(1));
+    ///     let expensive_val_1 = s.custom_nested("First nested segment", "Nested category", |_| {
+    ///         thread::sleep(Duration::from_secs(1));
+    ///         3
+    ///     });
+    ///     let expensive_val_2 = s.custom_nested("Second nested segment", "Nested category", |_| {
+    ///         thread::sleep(Duration::from_secs(1));
+    ///         2
+    ///     });
+    ///     expensive_val_1 * expensive_val_2
+    /// });
     /// ```
     pub fn create_custom_nested(&self, name: &str, category: &str) -> Self {
         // We can only create a nested segment if this segment is 'real'
@@ -837,8 +854,7 @@ impl<'a> Segment<'a> {
     ///         .operation("select")
     ///         .build()
     ///         .expect("Invalid datastore segment parameters");
-    ///     let _ = s.create_datastore_nested(&datastore_segment_params)
-    ///         .expect("Could not start nested segment");
+    ///     let _ = s.create_datastore_nested(&datastore_segment_params);
     ///     thread::sleep(Duration::from_secs(1));
     /// });
     /// ```
@@ -874,8 +890,7 @@ impl<'a> Segment<'a> {
     ///         .library("reqwest")
     ///         .build()
     ///         .expect("Invalid external segment parameters");
-    ///     let _ = s.create_external_nested(&external_segment_params)
-    ///         .expect("Could not start nested segment");
+    ///     let _ = s.create_external_nested(&external_segment_params);
     ///     thread::sleep(Duration::from_secs(1));
     /// });
     /// ```

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -362,8 +362,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
         category: impl AsRef<str>,
         func: F,
     ) -> Result<V>
-        where
-            F: FnOnce(ReferencingSegment<T>) -> V,
+    where
+        F: FnOnce(ReferencingSegment<T>) -> V,
     {
         Ok(func(self.create_custom_nested(name, category)?))
     }
@@ -401,8 +401,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     /// };
     /// ```
     pub fn datastore_nested<F, V>(&self, params: impl AsRef<DatastoreParams>, func: F) -> Result<V>
-        where
-            F: FnOnce(ReferencingSegment<T>) -> V,
+    where
+        F: FnOnce(ReferencingSegment<T>) -> V,
     {
         Ok(func(self.create_datastore_nested(params)?))
     }
@@ -440,8 +440,8 @@ impl<T: AsRef<Transaction> + Clone> ReferencingSegment<T> {
     /// };
     /// ```
     pub fn external_nested<F, V>(&self, params: impl AsRef<ExternalParams>, func: F) -> Result<V>
-        where
-            F: FnOnce(ReferencingSegment<T>) -> V,
+    where
+        F: FnOnce(ReferencingSegment<T>) -> V,
     {
         Ok(func(self.create_external_nested(params)?))
     }
@@ -710,8 +710,8 @@ impl<'a> Segment<'a> {
     /// });
     /// ```
     pub fn custom_nested<F, V>(&self, name: &str, category: &str, func: F) -> V
-        where
-            F: FnOnce(Segment) -> V,
+    where
+        F: FnOnce(Segment) -> V,
     {
         func(self.create_custom_nested(name, category))
     }
@@ -747,8 +747,8 @@ impl<'a> Segment<'a> {
     /// });
     /// ```
     pub fn datastore_nested<F, V>(&self, params: &DatastoreParams, func: F) -> V
-        where
-            F: FnOnce(Segment) -> V,
+    where
+        F: FnOnce(Segment) -> V,
     {
         func(self.create_datastore_nested(params))
     }
@@ -784,8 +784,8 @@ impl<'a> Segment<'a> {
     /// });
     /// ```
     pub fn external_nested<F, V>(&self, params: &ExternalParams, func: F) -> V
-        where
-            F: FnOnce(Segment) -> V,
+    where
+        F: FnOnce(Segment) -> V,
     {
         func(self.create_external_nested(params))
     }


### PR DESCRIPTION
# Content
Some examples were failing on master due to my changes. Here are the fixes.

# Testing

As a side comment, I found it surprisingly difficult to run the examples, which was in part a motivating factor on my laziness for not checking them properly. I had, of course, to have a newrelic licence, but getting the daemon to run in my local environment wasn't trivial either. The existing Dockerfile didn't work for me because the go image used seemed to lack the libpcre3-dev library. Also, since the version of go is old, the daemon doesn't build with the latest version. In the end, to avoid version trouble I wrote:

```docker
FROM golang:1.13 AS test_daemon
WORKDIR /go/src/app
COPY vendor/c-sdk .
RUN apt-get update && apt-get install -y libpcre3-dev
RUN make daemon
ENTRYPOINT ["/bin/bash"]
```

And then extracted the built image:
```bash
docker cp "test_newrelic_daemon_container:/go/src/app/newrelic-daemon" vendor/c-sdk/newrelic-daemon
```

And then ran it locally:
```bash
vendor/c-sdk/newrelic-daemon -f --loglevel debug --logfile ./newrelic.log
```

I leave this here as a record of how I tested it in case I need to do so in the future, or as a basis for changes to the existing Dockerfile if deemed necessary.

Here is a demonstration of the linting passing:

```
cargo fmt -- --check
cargo clippy -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
```

Here is a demonstration of the tests passing:
```
cargo test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/newrelic-3064e15d130bb98a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests newrelic

running 30 tests
test src/app.rs - app::NewRelicConfig (line 333) ... ok
test src/app.rs - app::NewRelicConfig<'a>::logging (line 432) ... ok
test src/app.rs - app::NewRelicConfig<'a>::socket (line 378) ... ok
test src/app.rs - app::NewRelicConfig<'a>::logging (line 422) ... ok
test src/app.rs - app::NewRelicConfig<'a>::timeout (line 397) ... ok
test src/app.rs - app::NewRelicConfig<'a>::init (line 456) ... ok
test src/lib.rs - (line 29) ... ok
test src/app.rs - app::AppBuilder (line 39) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::custom (line 225) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::datastore (line 259) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::external (line 294) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::datastore_nested (line 375) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::create_datastore_nested (line 498) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::external_nested (line 414) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::create_custom_nested (line 456) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::create_external_nested (line 539) ... ok
test src/segment.rs - segment::Segment<'a>::create_external_nested (line 874) ... ok
test src/segment.rs - segment::Segment<'a>::create_datastore_nested (line 838) ... ok
test src/transaction.rs - transaction::Transaction::custom_event (line 389) ... ok
test src/segment.rs - segment::ReferencingSegment<T>::custom_nested (line 332) ... ok
test src/segment.rs - segment::Segment<'a>::create_custom_nested (line 800) ... ok
test src/segment.rs - segment::Segment<'a>::external_nested (line 760) ... ok
test src/segment.rs - segment::Segment<'a>::datastore_nested (line 723) ... ok
test src/transaction.rs - transaction::Transaction::custom_segment (line 165) ... ok
test src/transaction.rs - transaction::Transaction::create_datastore_segment (line 289) ... ok
test src/transaction.rs - transaction::Transaction::create_custom_segment (line 319) ... ok
test src/transaction.rs - transaction::Transaction::create_external_segment (line 259) ... ok
test src/transaction.rs - transaction::Transaction::datastore_segment (line 193) ... ok
test src/transaction.rs - transaction::Transaction::external_segment (line 226) ... ok
test src/segment.rs - segment::Segment<'a>::custom_nested (line 687) ... ok

test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.40s
```